### PR TITLE
Feature/improve read speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ NFC reader RC-S380
 # installation
 ```bash
 sudo pip install nfcpy
+sudo pip install gTTS
 ```
+
+## for MacOS
+```bash
+brew install libusb
+```
+
 
 # run
 ```python
@@ -17,3 +24,4 @@ sudo python main.py
 
 # note
 You need to run as root.
+

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ import tkinter as tk
 
 class Attendance():
     def __init__(self):
-        self.clf = nfc.ContactlessFrontend("usb")
         self.logs = []
         # read log.csv and add todays logs
         today = datetime.now().date()
@@ -35,28 +34,29 @@ class Attendance():
     # with other card, dump data will be different and occur errors and die
     # need to check if scanned card is correct one
     def main(self):
-        f = open(self.log_file_path, "a") # even if exception occurs, data will be saved
-        writer = csv.writer(f)
-        while True:
-            try:
-                tag = self.clf.connect(rdwr={'on-connect': lambda tag: False})
-                target = tag.dump()[33]
-                target = target.split("|")[1]
-                student_number = target.split("002062")[0]
-                if not student_number in self.logs:
-                    timestamp = datetime.now()
-                    timestamp = timestamp.strftime("%Y-%m-%d %H:%M:%S")
-                    writer.writerow([timestamp, student_number])
-                    #self.student_number_to_mp3(student_number)
-                    #os.system("afplay greeting.mp3")
-                    self.logs.append(student_number)
-                    print(student_number)
-                    os.system("afplay ok.mp3")
-                else:
-                    print("already registered")
-                    os.system("afplay already_registered.mp3")
-            except nfc.tag.tt3.Type3TagCommandError:
-                print("error")
+        with nfc.ContactlessFrontend("usb") as clf:
+            with open(self.log_file_path, "a") as f:# even if exception occurs, data will be saved
+                writer = csv.writer(f)
+                while True:
+                    try:
+                        tag = clf.connect(rdwr={'on-connect': lambda tag: False})
+                        target = tag.dump()[33]
+                        target = target.split("|")[1]
+                        student_number = target.split("002062")[0]
+                        if not student_number in self.logs:
+                            timestamp = datetime.now()
+                            timestamp = timestamp.strftime("%Y-%m-%d %H:%M:%S")
+                            writer.writerow([timestamp, student_number])
+                            #self.student_number_to_mp3(student_number)
+                            #os.system("afplay greeting.mp3")
+                            self.logs.append(student_number)
+                            print(student_number)
+                            os.system("afplay ok.mp3")
+                        else:
+                            print("already registered")
+                            os.system("afplay already_registered.mp3")
+                    except nfc.tag.tt3.Type3TagCommandError:
+                        print("error")
 
 if __name__ == "__main__":
     attendance = Attendance()

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ class Attendance():
                 timestamp = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").date()
                 if timestamp == today:
                     self.logs.append(row[1])
-         
+
     def student_number_to_mp3(self, student_number):
         # ask for data
         table = {}
@@ -31,32 +31,59 @@ class Attendance():
         engine = gTTS(text=speech_text, lang="en", slow=False)
         engine.save("greeting.mp3")
 
+    def on_connect(self, tag):
+        # Service一覧の出力
+        # for i in range(0x10000):
+        #     area_or_service = tag.search_service_code(i)
+        #     if area_or_service is None:
+        #         break
+        #     elif len(area_or_service) == 1:
+        #         sc = area_or_service[0]
+        #         print(nfc.tag.tt3.ServiceCode(sc >> 6, sc & 0x3f))
+        #     elif len(area_or_service) == 2:
+        #         area_code, area_last = area_or_service
+        #         print("Area {0:04x}--{0:04x}".format(area_code, area_last))
+        #         #    Random Service 68: write with key & read w/o key (0x1108 0x110B)
+        #         #    Random Service 72: write with key & read w/o key (0x1208 0x120B)
+        #         #    Random Service 76: write with key & read w/o key (0x1308 0x130B)
+
+        # dump実行結果の出力
+        # dumped = tag.dump()
+        # for row in dumped:
+        #     print(row)
+
+        # read_without_encryptionを使えば特定アドレスだけdumpできそう
+        # https://nfcpy.readthedocs.io/en/latest/modules/tag.html#nfc.tag.tt3.Type3Tag.read_without_encryption
+        # sc1 = nfc.tag.tt3.ServiceCode(76, 0x1308)
+        # print(tag.read_without_encryption([sc1]))
+
+        target = tag.dump()[33]
+        target = target.split("|")[1]
+        student_number = target.split("002062")[0]
+        if not student_number in self.logs:
+            timestamp = datetime.now()
+            timestamp = timestamp.strftime("%Y-%m-%d %H:%M:%S")
+            with open(self.log_file_path, "a") as f:  # even if exception occurs, data will be saved
+                writer = csv.writer(f)
+                writer.writerow([timestamp, student_number])
+            # self.student_number_to_mp3(student_number)
+            # os.system("afplay greeting.mp3")
+            self.logs.append(student_number)
+            print(student_number)
+            os.system("afplay ok.mp3")
+        else:
+            print("already registered")
+            os.system("afplay already_registered.mp3")
+
     # with other card, dump data will be different and occur errors and die
     # need to check if scanned card is correct one
     def main(self):
         with nfc.ContactlessFrontend("usb") as clf:
-            with open(self.log_file_path, "a") as f:# even if exception occurs, data will be saved
-                writer = csv.writer(f)
-                while True:
-                    try:
-                        tag = clf.connect(rdwr={'on-connect': lambda tag: False})
-                        target = tag.dump()[33]
-                        target = target.split("|")[1]
-                        student_number = target.split("002062")[0]
-                        if not student_number in self.logs:
-                            timestamp = datetime.now()
-                            timestamp = timestamp.strftime("%Y-%m-%d %H:%M:%S")
-                            writer.writerow([timestamp, student_number])
-                            #self.student_number_to_mp3(student_number)
-                            #os.system("afplay greeting.mp3")
-                            self.logs.append(student_number)
-                            print(student_number)
-                            os.system("afplay ok.mp3")
-                        else:
-                            print("already registered")
-                            os.system("afplay already_registered.mp3")
-                    except nfc.tag.tt3.Type3TagCommandError:
-                        print("error")
+            while True:
+                try:
+                    clf.connect(rdwr={'on-connect': self.on_connect})
+                except nfc.tag.tt3.Type3TagCommandError:
+                    print("error")
 
 if __name__ == "__main__":
     attendance = Attendance()


### PR DESCRIPTION
# WHY

- NFCリーダーの読み込み速度改善

# WHAT

- `tag.dump` を利用して全データを出力しているため、特定アドレスのみ取得できれば高速化ができる
- その他実装不備の微修正

# HOW

- `open` 及び`nfc.ContactlessFrontend("usb")` がそれぞれcloseを伴わない実装になっていたため、with記法によりcloseを保証
- `on-connect` callbackを正しく利用するように修正
- `tag.read_without_encryption()` もしくは `tag.read_from_ndef_service()` を正しく使うことで読み取り高速化がおそらくできそう
  - 関連する